### PR TITLE
Fix some bugs in codegen test cases.

### DIFF
--- a/codegen/e1.mx
+++ b/codegen/e1.mx
@@ -4,11 +4,11 @@ Author: Pikachu
 Time: 2020-02-02
 Input:
 === input ===
-nniinneetteeeenn
+79 35 12
 === end ===
 Output:
 === output ===
-2
+<< 23 24 25 26 27 28 29 30 31 32 33 34 (35) 36 37 38 39 40 41 42 43 44 45 46 47 >>
 === end ===
 ExitCode: 0
 InstLimit: -1
@@ -17,12 +17,13 @@ Origin Package: Codeforces 399A #44003944
 int n;
 int p;
 int k;
+int i;
 int main() {
 	n = getInt();
 	p = getInt();
 	k = getInt();
 	if(p-k>1) print("<< ");
-	for(int i= p-k; i<=p+k;i++)
+	for(i= p-k; i<=p+k;i++)
 	      if(1<= i && i <= n) {
 	         if(i==p){
 				 print("(");

--- a/codegen/e2.mx
+++ b/codegen/e2.mx
@@ -20,9 +20,9 @@ int[] a = new int[20];
 int jud(int x){
 	int i,j;
 	for(i=0;i<n/x;i++){
-		int flag=0;
+		bool flag=false;
 		for(j=0;j<x-1;j++){
-			if(a[i*x+j]>a[i*x+j+1])flag=1;
+			if(a[i*x+j]>a[i*x+j+1])flag=true;
 		}
 		if(!flag)return 1;
 	}

--- a/codegen/e5.mx
+++ b/codegen/e5.mx
@@ -27,7 +27,7 @@ int main(){
         s = getString();
 		l = s.length();
 		if(l > 10)
-            println(s.substring(0, 1) + toString(l-2) + s.substring(l-1, l))
+            println(s.substring(0, 1) + toString(l-2) + s.substring(l-1, l));
 			// printf("%c%d%c\n",s[0],l-2,s[l-1]);
 		else
 			// printf("%s\n",s);

--- a/codegen/t18.mx
+++ b/codegen/t18.mx
@@ -1018,7 +1018,7 @@ class node {
 	int key;
     int data;
 	node next;
-}
+};
 node[] table;
 int getHash(int n) {
 	return (n * 237) % hashsize;

--- a/codegen/t22.mx
+++ b/codegen/t22.mx
@@ -64,7 +64,7 @@ int j;
 class rec {
     int num;
     int c;
-}
+};
 
 rec[] b = new rec[5];
 

--- a/codegen/t24.mx
+++ b/codegen/t24.mx
@@ -4,7 +4,6 @@ Author: 10' Huan Yang
 Time: 2020-02-02
 Input:
 === input ===
-10
 === end ===
 Output:
 === output ===

--- a/codegen/t29.mx
+++ b/codegen/t29.mx
@@ -1,4 +1,5 @@
 /*
+The same as t28.xm
 Test Package: Codegen
 Author: 09' Xiao Jia
 Time: 2020-02-02

--- a/codegen/t32.mx
+++ b/codegen/t32.mx
@@ -4,7 +4,6 @@ Author: 11' Tianxing Jin
 Time: 2020-02-02
 Input:
 === input ===
-168
 === end ===
 Output:
 === output ===

--- a/codegen/t59.mx
+++ b/codegen/t59.mx
@@ -1,4 +1,5 @@
 /*
+200 numbers are required in line 33-36. But there are only 100 numbers in line 9.
 Test Package: Codegen
 Author: 14' Rongyu You
 Time: 2020-02-03

--- a/codegen/t61.mx
+++ b/codegen/t61.mx
@@ -104,7 +104,7 @@ class vector{
 		}
 		return true;
 	}
-}
+};
 
 int main(){
 	vector x = new vector;

--- a/codegen/t65.mx
+++ b/codegen/t65.mx
@@ -60,7 +60,7 @@ string asciiTable = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXY
 string int2chr(int x)
 {
 	if(x >= 32 && x <= 126)
-		return asciiTable.substring(x-32, x-32);
+		return asciiTable.substring(x-32, x-31);
 	return "";
 }
 string toStringHex(int x)
@@ -239,7 +239,7 @@ void crackSHA1(string input)
 	for(i=0;i<5;i++)
 		target[i] = 0;
 	for(i=0;i<40;i=i+4)
-		target[i/8] = target[i/8] | (hex2int(input.substring(i, i+3)) << (1 - (i / 4) % 2) * 16);
+		target[i/8] = target[i/8] | (hex2int(input.substring(i, i+4)) << (1 - (i / 4) % 2) * 16);
 
 	int MAXDIGIT = 4;
 	int digit;


### PR DESCRIPTION
e1.mx: Wrong input & output. Extract "int i" from loop initialization to global declaration.
e2.mx: Set "flag" in line 23 to bool type.
e5.mx: Add semicolon to the end of line 30.
t18.mx: Add semicolon to the class "node" definition.
t22.mx: Add semicolon to the class "rec" definition.
t24.mx: No input is required.
t29.mx: The test is the same as t28.mx
t32.mx: No input is required.
t59.mx: Invalid input. 200 numbers are required in line 33-36. But there are only 100 numbers in line 9.
t61.mx: Add semicolon to the class "vector" definition.
t65.mx: Modify the parameter of "string.substring(left, right)" call so that the method returns the substring [left, right).